### PR TITLE
Update root application to redirect to app subdomain

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -56,7 +56,8 @@ export default async function middleware(req: NextRequest) {
     hostname === process.env.NEXT_PUBLIC_ROOT_DOMAIN
   ) {
     if (path === "/") {
-      return NextResponse.redirect(new URL("/login", req.url));
+      const appUrl = req.url.replace(hostname, `app.${hostname}`);
+      return NextResponse.redirect(new URL("/login", appUrl));
     } else {
       return NextResponse.rewrite(new URL(`/home${path}`, req.url));
     }


### PR DESCRIPTION
## Description

This redirects base path URLs to the `app.` subdomain 

## Motivation and Context

Adds on to fbe1562 for even better local dev experience. Aka I was initially confused by a 404 error on `http://localhost:3000/login` for a bit before figuring out that I should add `app.` in front 😅 

## How Has This Been Tested?

This has been tested locally:
1. `localhost:3000` redirects to `app.localhost:3000/login`
2. Navigating directly to `app.localhost:3000/login` shows the login page

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Intrepid? If so please include proposed documentation changes below -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.