### PR TITLE
Fix Email Editor Validation and Initialize Default Content

### DIFF
--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -114,7 +114,7 @@ export default function Editor({ email }: { email: EmailWithSite }) {
           {isPendingSaving ? "Saving..." : "Saved"}
         </div>
         <button
-          onClick={() => startTransitionPublishing(handlePublish)}
+          onClick={() => startTransitionPublishing(handleClickPublish)}
           className={cn(
             "flex h-7 w-24 items-center justify-center space-x-2 rounded-lg border text-sm transition-all focus:outline-none",
             isPendingPublishing


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR includes the following fixes to the email editor:

- Validates that campaign name, subject, and recipient ("to") fields are required before publishing.
- Ensures content is not empty before publishing.
- Initializes the editor with default content.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These changes prevent publishing emails with missing essential fields or empty content, ensuring complete and structured emails.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally by:

- Attempting to publish with missing required fields to verify validation.
- Confirming successful publishing with all required fields filled.
- Verifying default content initialization and non-empty content validation.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Intrepid? If so please include proposed documentation changes below -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.