### PR TITLE
feat: add SES webhook handling for bounces and complaints

### DIFF
--- a/app/api/ses-webhook/route.test.ts
+++ b/app/api/ses-webhook/route.test.ts
@@ -46,7 +46,7 @@ describe("POST /api/ses-webhook", () => {
             bounceType: "Permanent",
             bounceSubType: "General",
             timestamp: "2026-03-24T10:00:00.000Z",
-            bouncedRecipients: [{ emailAddress: "bounced@example.com" }],
+            bouncedRecipients: [{ emailAddress: "Bounced@Example.com" }],
           },
         }),
       }),
@@ -69,5 +69,85 @@ describe("POST /api/ses-webhook", () => {
         sourceEmail: undefined,
       },
     });
+  });
+
+  test("adds complaint recipients to suppression even when the email record is not found", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/ses-webhook", {
+      method: "POST",
+      body: JSON.stringify({
+        Type: "Notification",
+        MessageId: "sns-complaint-1",
+        TopicArn: "arn:aws:sns:us-east-1:123:mailer",
+        Timestamp: "2026-03-24T11:00:00.000Z",
+        Message: JSON.stringify({
+          eventType: "Complaint",
+          mail: {
+            messageId: "ses-message-complaint-1",
+            timestamp: "2026-03-24T11:00:00.000Z",
+            source: "mailer@example.com",
+            destination: ["complained@example.com"],
+          },
+          complaint: {
+            complaintFeedbackType: "abuse",
+            timestamp: "2026-03-24T11:00:00.000Z",
+            complainedRecipients: [{ emailAddress: "Complained@Example.com" }],
+          },
+        }),
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockPrisma.emailSuppression.upsert).toHaveBeenCalledWith({
+      where: { email: "complained@example.com" },
+      update: {
+        reason: "COMPLAINT",
+        sourceEmail: undefined,
+      },
+      create: {
+        email: "complained@example.com",
+        reason: "COMPLAINT",
+        sourceEmail: undefined,
+      },
+    });
+  });
+
+  test("does not add non-permanent bounce recipients to suppression", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/ses-webhook", {
+      method: "POST",
+      body: JSON.stringify({
+        Type: "Notification",
+        MessageId: "sns-2",
+        TopicArn: "arn:aws:sns:us-east-1:123:mailer",
+        Timestamp: "2026-03-24T12:00:00.000Z",
+        Message: JSON.stringify({
+          eventType: "Bounce",
+          mail: {
+            messageId: "ses-message-2",
+            timestamp: "2026-03-24T12:00:00.000Z",
+            source: "mailer@example.com",
+            destination: ["soft-bounced@example.com"],
+          },
+          bounce: {
+            bounceType: "Transient",
+            bounceSubType: "General",
+            timestamp: "2026-03-24T12:00:00.000Z",
+            bouncedRecipients: [{ emailAddress: "soft-bounced@example.com" }],
+          },
+        }),
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockPrisma.emailSuppression.upsert).not.toHaveBeenCalled();
   });
 });

--- a/app/api/ses-webhook/route.test.ts
+++ b/app/api/ses-webhook/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockPrisma = {
+  email: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  emailEvent: {
+    create: vi.fn(),
+  },
+  emailSuppression: {
+    upsert: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({ default: mockPrisma }));
+vi.mock("@/lib/utils", () => ({ logError: vi.fn() }));
+
+describe("POST /api/ses-webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.email.findFirst.mockResolvedValue(null);
+    mockPrisma.email.findUnique.mockResolvedValue(null);
+    mockPrisma.emailSuppression.upsert.mockResolvedValue({});
+  });
+
+  test("adds permanent bounce recipients to suppression even when the email record is not found", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/ses-webhook", {
+      method: "POST",
+      body: JSON.stringify({
+        Type: "Notification",
+        MessageId: "sns-1",
+        TopicArn: "arn:aws:sns:us-east-1:123:mailer",
+        Timestamp: "2026-03-24T10:00:00.000Z",
+        Message: JSON.stringify({
+          eventType: "Bounce",
+          mail: {
+            messageId: "ses-message-1",
+            timestamp: "2026-03-24T10:00:00.000Z",
+            source: "mailer@example.com",
+            destination: ["bounced@example.com"],
+          },
+          bounce: {
+            bounceType: "Permanent",
+            bounceSubType: "General",
+            timestamp: "2026-03-24T10:00:00.000Z",
+            bouncedRecipients: [{ emailAddress: "bounced@example.com" }],
+          },
+        }),
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockPrisma.emailSuppression.upsert).toHaveBeenCalledWith({
+      where: { email: "bounced@example.com" },
+      update: {
+        reason: "HARD_BOUNCE",
+        sourceEmail: undefined,
+      },
+      create: {
+        email: "bounced@example.com",
+        reason: "HARD_BOUNCE",
+        sourceEmail: undefined,
+      },
+    });
+  });
+});

--- a/app/api/ses-webhook/route.ts
+++ b/app/api/ses-webhook/route.ts
@@ -136,23 +136,50 @@ async function addToSuppressionList(
   sourceEmailId?: string,
 ) {
   for (const email of emails) {
+    const normalizedEmail = email.trim().toLowerCase();
+
     try {
       await prisma.emailSuppression.upsert({
-        where: { email },
+        where: { email: normalizedEmail },
         update: {
           reason,
           sourceEmail: sourceEmailId,
         },
         create: {
-          email,
+          email: normalizedEmail,
           reason,
           sourceEmail: sourceEmailId,
         },
       });
     } catch (error) {
-      logError("Failed to add email to suppression list", error, { email });
+      logError("Failed to add email to suppression list", error, {
+        email: normalizedEmail,
+      });
     }
   }
+}
+
+function getSuppressionData(
+  event: SesEvent,
+): { emails: string[]; reason: string } | null {
+  if (
+    event.eventType === "Bounce" &&
+    event.bounce?.bounceType === "Permanent"
+  ) {
+    return {
+      emails: event.bounce.bouncedRecipients.map((r) => r.emailAddress),
+      reason: "HARD_BOUNCE",
+    };
+  }
+
+  if (event.eventType === "Complaint" && event.complaint) {
+    return {
+      emails: event.complaint.complainedRecipients.map((r) => r.emailAddress),
+      reason: "COMPLAINT",
+    };
+  }
+
+  return null;
 }
 
 // Process SES event and update database
@@ -190,21 +217,12 @@ async function processSesEvent(event: SesEvent) {
   }
 
   if (!email) {
-    if (
-      event.eventType === "Bounce" &&
-      event.bounce?.bounceType === "Permanent"
-    ) {
-      const bouncedEmails = event.bounce.bouncedRecipients.map(
-        (r) => r.emailAddress,
+    const suppressionData = getSuppressionData(event);
+    if (suppressionData) {
+      await addToSuppressionList(
+        suppressionData.emails,
+        suppressionData.reason,
       );
-      await addToSuppressionList(bouncedEmails, "HARD_BOUNCE");
-    }
-
-    if (event.eventType === "Complaint" && event.complaint) {
-      const complainedEmails = event.complaint.complainedRecipients.map(
-        (r) => r.emailAddress,
-      );
-      await addToSuppressionList(complainedEmails, "COMPLAINT");
     }
 
     // Log but don't fail - email might have been deleted
@@ -270,23 +288,13 @@ async function processSesEvent(event: SesEvent) {
     }
   }
 
-  // Handle hard bounces - add to suppression list
-  if (
-    event.eventType === "Bounce" &&
-    event.bounce?.bounceType === "Permanent"
-  ) {
-    const bouncedEmails = event.bounce.bouncedRecipients.map(
-      (r) => r.emailAddress,
+  const suppressionData = getSuppressionData(event);
+  if (suppressionData) {
+    await addToSuppressionList(
+      suppressionData.emails,
+      suppressionData.reason,
+      email.id,
     );
-    await addToSuppressionList(bouncedEmails, "HARD_BOUNCE", email.id);
-  }
-
-  // Handle complaints - add to suppression list
-  if (event.eventType === "Complaint" && event.complaint) {
-    const complainedEmails = event.complaint.complainedRecipients.map(
-      (r) => r.emailAddress,
-    );
-    await addToSuppressionList(complainedEmails, "COMPLAINT", email.id);
   }
 }
 

--- a/app/api/ses-webhook/route.ts
+++ b/app/api/ses-webhook/route.ts
@@ -190,6 +190,23 @@ async function processSesEvent(event: SesEvent) {
   }
 
   if (!email) {
+    if (
+      event.eventType === "Bounce" &&
+      event.bounce?.bounceType === "Permanent"
+    ) {
+      const bouncedEmails = event.bounce.bouncedRecipients.map(
+        (r) => r.emailAddress,
+      );
+      await addToSuppressionList(bouncedEmails, "HARD_BOUNCE");
+    }
+
+    if (event.eventType === "Complaint" && event.complaint) {
+      const complainedEmails = event.complaint.complainedRecipients.map(
+        (r) => r.emailAddress,
+      );
+      await addToSuppressionList(complainedEmails, "COMPLAINT");
+    }
+
     // Log but don't fail - email might have been deleted
     logError("SES webhook: email not found", null, {
       sesMessageId,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Add SES webhook handling for bounces and complaints with unit tests

## Motivation and Context
- Closes #203 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

QA steps:

- Add bounce@simulator.amazonses.com to People.
- Send an email to that contact.
- Verify the bounced address appears in the suppression list automatically.