### PR TITLE
feat: add email queue cron endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,9 @@ EMAIL_DOMAIN=
 # Upstash: rediss://default:xxx@xxx.upstash.io:6379
 REDIS_URL=redis://localhost:6379
 
+# Optional bearer token for /api/cron/email-queue
+CRON_SECRET=
+
 # ===========================================
 # AWS SES Configuration (REQUIRED when DEFAULT_EMAIL_PROVIDER=ses)
 # ===========================================

--- a/app/api/cron/email-queue/route.test.ts
+++ b/app/api/cron/email-queue/route.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/queue", () => ({
 
 const ORIGINAL_ENV = { ...process.env };
 
-describe("GET /api/cron/email-queue", () => {
+describe("POST /api/cron/email-queue", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
@@ -26,10 +26,11 @@ describe("GET /api/cron/email-queue", () => {
 
   test("returns 503 when Redis is not configured", async () => {
     delete process.env.REDIS_URL;
-    const { GET } = await import("./route");
+    const { POST } = await import("./route");
 
-    const response = await GET(
+    const response = await POST(
       new Request("http://localhost/api/cron/email-queue", {
+        method: "POST",
         headers: { authorization: "Bearer test-secret" },
       }),
     );
@@ -49,9 +50,10 @@ describe("GET /api/cron/email-queue", () => {
       delayed: 3,
     });
 
-    const { GET } = await import("./route");
-    const responsePromise = GET(
+    const { POST } = await import("./route");
+    const responsePromise = POST(
       new Request("http://localhost/api/cron/email-queue", {
+        method: "POST",
         headers: { authorization: "Bearer test-secret" },
       }),
     );
@@ -78,9 +80,10 @@ describe("GET /api/cron/email-queue", () => {
   test("returns 500 when queue processing fails", async () => {
     mockGetQueueStats.mockRejectedValue(new Error("queue failed"));
 
-    const { GET } = await import("./route");
-    const responsePromise = GET(
+    const { POST } = await import("./route");
+    const responsePromise = POST(
       new Request("http://localhost/api/cron/email-queue", {
+        method: "POST",
         headers: { authorization: "Bearer test-secret" },
       }),
     );
@@ -96,10 +99,12 @@ describe("GET /api/cron/email-queue", () => {
   });
 
   test("returns 401 when auth token is missing or invalid", async () => {
-    const { GET } = await import("./route");
+    const { POST } = await import("./route");
 
-    const response = await GET(
-      new Request("http://localhost/api/cron/email-queue"),
+    const response = await POST(
+      new Request("http://localhost/api/cron/email-queue", {
+        method: "POST",
+      }),
     );
     const body = await response.json();
 
@@ -118,9 +123,11 @@ describe("GET /api/cron/email-queue", () => {
       delayed: 0,
     });
 
-    const { GET } = await import("./route");
-    const responsePromise = GET(
-      new Request("http://localhost/api/cron/email-queue"),
+    const { POST } = await import("./route");
+    const responsePromise = POST(
+      new Request("http://localhost/api/cron/email-queue", {
+        method: "POST",
+      }),
     );
 
     await vi.advanceTimersByTimeAsync(15_000);
@@ -133,7 +140,7 @@ describe("GET /api/cron/email-queue", () => {
     expect(mockStartEmailWorker).toHaveBeenCalledTimes(1);
   });
 
-  test("accepts POST requests with token in query string", async () => {
+  test("rejects POST requests without the authorization header when CRON_SECRET is set", async () => {
     mockGetQueueStats.mockResolvedValue({
       waiting: 1,
       active: 0,
@@ -143,20 +150,15 @@ describe("GET /api/cron/email-queue", () => {
     });
 
     const { POST } = await import("./route");
-    const responsePromise = POST(
-      new Request("http://localhost/api/cron/email-queue?token=test-secret", {
+    const response = await POST(
+      new Request("http://localhost/api/cron/email-queue", {
         method: "POST",
       }),
     );
-
-    await vi.advanceTimersByTimeAsync(15_000);
-
-    const response = await responsePromise;
     const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body.ok).toBe(true);
-    expect(body.stats.waiting).toBe(1);
-    expect(mockStartEmailWorker).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockStartEmailWorker).not.toHaveBeenCalled();
   });
 });

--- a/app/api/cron/email-queue/route.test.ts
+++ b/app/api/cron/email-queue/route.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockGetQueueStats = vi.fn();
+const mockStartEmailWorker = vi.fn();
+
+vi.mock("@/lib/queue", () => ({
+  getQueueStats: (...args: unknown[]) => mockGetQueueStats(...args),
+  startEmailWorker: (...args: unknown[]) => mockStartEmailWorker(...args),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("GET /api/cron/email-queue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    process.env = { ...ORIGINAL_ENV };
+    process.env.CRON_SECRET = "test-secret";
+    process.env.REDIS_URL = "redis://localhost:6379";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("returns 503 when Redis is not configured", async () => {
+    delete process.env.REDIS_URL;
+    const { GET } = await import("./route");
+
+    const response = await GET(
+      new Request("http://localhost/api/cron/email-queue", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe("REDIS_URL environment variable is not set");
+    expect(mockStartEmailWorker).not.toHaveBeenCalled();
+  });
+
+  test("starts the worker and returns queue stats", async () => {
+    mockGetQueueStats.mockResolvedValue({
+      waiting: 0,
+      active: 0,
+      completed: 2,
+      failed: 0,
+      delayed: 3,
+    });
+
+    const { GET } = await import("./route");
+    const responsePromise = GET(
+      new Request("http://localhost/api/cron/email-queue", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.waitedMs).toBe(15_000);
+    expect(body.stats).toEqual({
+      waiting: 0,
+      active: 0,
+      completed: 2,
+      failed: 0,
+      delayed: 3,
+    });
+    expect(mockStartEmailWorker).toHaveBeenCalledTimes(1);
+    expect(mockGetQueueStats).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 500 when queue processing fails", async () => {
+    mockGetQueueStats.mockRejectedValue(new Error("queue failed"));
+
+    const { GET } = await import("./route");
+    const responsePromise = GET(
+      new Request("http://localhost/api/cron/email-queue", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("queue failed");
+    expect(mockStartEmailWorker).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 401 when auth token is missing or invalid", async () => {
+    const { GET } = await import("./route");
+
+    const response = await GET(
+      new Request("http://localhost/api/cron/email-queue"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockStartEmailWorker).not.toHaveBeenCalled();
+  });
+
+  test("does not require auth when CRON_SECRET is unset", async () => {
+    delete process.env.CRON_SECRET;
+    mockGetQueueStats.mockResolvedValue({
+      waiting: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+      delayed: 0,
+    });
+
+    const { GET } = await import("./route");
+    const responsePromise = GET(
+      new Request("http://localhost/api/cron/email-queue"),
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockStartEmailWorker).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts POST requests with token in query string", async () => {
+    mockGetQueueStats.mockResolvedValue({
+      waiting: 1,
+      active: 0,
+      completed: 0,
+      failed: 0,
+      delayed: 0,
+    });
+
+    const { POST } = await import("./route");
+    const responsePromise = POST(
+      new Request("http://localhost/api/cron/email-queue?token=test-secret", {
+        method: "POST",
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.stats.waiting).toBe(1);
+    expect(mockStartEmailWorker).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/cron/email-queue/route.ts
+++ b/app/api/cron/email-queue/route.ts
@@ -9,12 +9,9 @@ export const runtime = "nodejs";
 
 async function runCron(request: Request) {
   const cronSecret = process.env.CRON_SECRET;
-  const url = new URL(request.url);
-  const querySecret = url.searchParams.get("token");
   if (
     cronSecret &&
-    request.headers.get("authorization") !== `Bearer ${cronSecret}` &&
-    querySecret !== cronSecret
+    request.headers.get("authorization") !== `Bearer ${cronSecret}`
   ) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -54,10 +51,6 @@ async function runCron(request: Request) {
       { status: 500 },
     );
   }
-}
-
-export async function GET(request: Request) {
-  return runCron(request);
 }
 
 export async function POST(request: Request) {

--- a/app/api/cron/email-queue/route.ts
+++ b/app/api/cron/email-queue/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+import { getQueueStats, startEmailWorker } from "@/lib/queue";
+
+const CRON_WAIT_MS = 15_000;
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+async function runCron(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  const url = new URL(request.url);
+  const querySecret = url.searchParams.get("token");
+  if (
+    cronSecret &&
+    request.headers.get("authorization") !== `Bearer ${cronSecret}` &&
+    querySecret !== cronSecret
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!process.env.REDIS_URL) {
+    return NextResponse.json(
+      { error: "REDIS_URL environment variable is not set" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    startEmailWorker();
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, CRON_WAIT_MS);
+    });
+
+    const stats = await getQueueStats();
+
+    return NextResponse.json(
+      { ok: true, waitedMs: CRON_WAIT_MS, stats },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Error running email queue cron:", error);
+
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to run email queue",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  return runCron(request);
+}
+
+export async function POST(request: Request) {
+  return runCron(request);
+}

--- a/app/app/(dashboard)/email/[id]/page.tsx
+++ b/app/app/(dashboard)/email/[id]/page.tsx
@@ -38,6 +38,7 @@ export default async function EmailDetailPage({
   const isScheduled = email.scheduledTime > now;
   const isSent = !isScheduled;
   const timeZone = email.organization?.timezone;
+  const displayTimeZone = timeZone?.replace(/_/g, " ");
   const formatDateTime = (date: Date) =>
     date.toLocaleString("en-US", {
       dateStyle: "medium",
@@ -126,7 +127,7 @@ export default async function EmailDetailPage({
               <time dateTime={email.scheduledTime.toISOString()}>
                 {formatDateTime(email.scheduledTime)}
               </time>
-              {timeZone ? ` (${timeZone})` : ""}
+              {displayTimeZone ? ` (${displayTimeZone})` : ""}
             </span>
             <CancelScheduleModal
               emailId={email.id}
@@ -141,7 +142,7 @@ export default async function EmailDetailPage({
             <time dateTime={email.updatedAt.toISOString()}>
               {formatDateTime(email.updatedAt)}
             </time>
-            {timeZone ? ` (${timeZone})` : ""}
+            {displayTimeZone ? ` (${displayTimeZone})` : ""}
           </div>
         )}
       </section>

--- a/app/app/(dashboard)/email/[id]/page.tsx
+++ b/app/app/(dashboard)/email/[id]/page.tsx
@@ -25,6 +25,7 @@ export default async function EmailDetailPage({
     where: { id: decodeURIComponent(id) },
     include: {
       audienceList: { include: { audiences: true } },
+      organization: { select: { timezone: true } },
     },
   });
   if (!email || email.userId !== session.user.id) return notFound();
@@ -36,6 +37,13 @@ export default async function EmailDetailPage({
   const now = new Date();
   const isScheduled = email.scheduledTime > now;
   const isSent = !isScheduled;
+  const timeZone = email.organization?.timezone;
+  const formatDateTime = (date: Date) =>
+    date.toLocaleString("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      ...(timeZone ? { timeZone } : {}),
+    });
 
   let previewHtml = "<p>No preview available</p>";
   if (email.content) {
@@ -116,21 +124,24 @@ export default async function EmailDetailPage({
             <span className="text-base font-medium text-yellow-600 dark:text-yellow-400">
               Scheduled for{" "}
               <time dateTime={email.scheduledTime.toISOString()}>
-                {new Date(email.scheduledTime).toLocaleString()}
+                {formatDateTime(email.scheduledTime)}
               </time>
+              {timeZone ? ` (${timeZone})` : ""}
             </span>
             <CancelScheduleModal
               emailId={email.id}
               scheduledTime={email.scheduledTime.toISOString()}
               organizationId={email.organizationId || undefined}
+              timezone={timeZone}
             />
           </div>
         ) : (
           <div className="text-base text-gray-500 dark:text-gray-400">
             Sent at{" "}
             <time dateTime={email.updatedAt.toISOString()}>
-              {new Date(email.updatedAt).toLocaleString()}
+              {formatDateTime(email.updatedAt)}
             </time>
+            {timeZone ? ` (${timeZone})` : ""}
           </div>
         )}
       </section>

--- a/components/email-row.tsx
+++ b/components/email-row.tsx
@@ -49,6 +49,7 @@ export default function EmailRow({
   const published = data.published;
   const scheduled = published && new Date(data.scheduledTime) > now;
   const appTimeZone = data.organization?.timezone;
+  const displayTimeZone = appTimeZone?.replace(/_/g, " ");
 
   const timestamp = !published
     ? new Date(data.updatedAt)
@@ -148,9 +149,9 @@ export default function EmailRow({
               <span className="text-xs text-gray-500 dark:text-gray-400">
                 {formatTime(timestamp, appTimeZone)}
               </span>
-              {appTimeZone ? (
+              {displayTimeZone ? (
                 <span className="truncate text-[11px] text-gray-400 dark:text-gray-500">
-                  {appTimeZone}
+                  {displayTimeZone}
                 </span>
               ) : null}
             </div>

--- a/components/email-row.tsx
+++ b/components/email-row.tsx
@@ -21,16 +21,19 @@ import {
 import { Button } from "@/components/ui/button";
 import { deleteEmail } from "@/lib/actions";
 
-const fmtDate = (d: Date) =>
-  d.toLocaleDateString(undefined, {
+const formatDate = (date: Date, timeZone?: string | null) =>
+  date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
+    ...(timeZone ? { timeZone } : {}),
   });
-const fmtTime = (d: Date) =>
-  d.toLocaleTimeString(undefined, {
+
+const formatTime = (date: Date, timeZone?: string | null) =>
+  date.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
+    ...(timeZone ? { timeZone, timeZoneName: "short" as const } : {}),
   });
 
 export default function EmailRow({
@@ -45,6 +48,7 @@ export default function EmailRow({
   const now = new Date();
   const published = data.published;
   const scheduled = published && new Date(data.scheduledTime) > now;
+  const appTimeZone = data.organization?.timezone;
 
   const timestamp = !published
     ? new Date(data.updatedAt)
@@ -139,11 +143,16 @@ export default function EmailRow({
                 {timeLabel}
               </span>
               <span className="truncate text-base font-semibold text-gray-900 dark:text-gray-100">
-                {fmtDate(timestamp)}
+                {formatDate(timestamp, appTimeZone)}
               </span>
               <span className="text-xs text-gray-500 dark:text-gray-400">
-                {fmtTime(timestamp)}
+                {formatTime(timestamp, appTimeZone)}
               </span>
+              {appTimeZone ? (
+                <span className="truncate text-[11px] text-gray-400 dark:text-gray-500">
+                  {appTimeZone}
+                </span>
+              ) : null}
             </div>
           </Link>
         </td>
@@ -160,6 +169,7 @@ export default function EmailRow({
                 <CancelScheduleModal
                   emailId={data.id}
                   scheduledTime={data.scheduledTime.toISOString()}
+                  timezone={appTimeZone}
                 />
               </>
             )}

--- a/components/email-wizard/step-4-schedule-send.tsx
+++ b/components/email-wizard/step-4-schedule-send.tsx
@@ -27,6 +27,7 @@ export function Step4ScheduleSend({
   timezone = DEFAULT_TIMEZONE,
 }: Step4ScheduleSendProps) {
   const { formData, organizationId, updateFormData } = useWizard();
+  const displayTimezone = timezone.replace(/_/g, " ");
   const [mode, setMode] = useState<SendMode>("now");
   const didInitMode = useRef(false);
   const [testEmail, setTestEmail] = useState("");
@@ -216,7 +217,8 @@ export function Step4ScheduleSend({
                   timezone={timezone}
                 />
                 <p className="text-xs text-gray-600 dark:text-gray-400">
-                  Timezone: <span className="font-medium">{timezone}</span>
+                  Timezone:{" "}
+                  <span className="font-medium">{displayTimezone}</span>
                 </p>
               </div>
             )}

--- a/components/modal/cancel-schedule-modal.tsx
+++ b/components/modal/cancel-schedule-modal.tsx
@@ -33,6 +33,7 @@ export default function CancelScheduleModal({
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const displayTimeZone = timezone?.replace(/_/g, " ");
 
   const handleUnschedule = async () => {
     setLoading(true);
@@ -80,8 +81,8 @@ export default function CancelScheduleModal({
             <AlertDialogDescription>
               Scheduled for{" "}
               <time dateTime={scheduledTime}>{scheduledLabel}</time>. Are you
-              {timezone ? ` (${timezone})` : ""}. Are you sure you want to move
-              it back to draft?
+              {displayTimeZone ? ` (${displayTimeZone})` : ""}. Are you sure you
+              want to move it back to draft?
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/components/modal/cancel-schedule-modal.tsx
+++ b/components/modal/cancel-schedule-modal.tsx
@@ -21,12 +21,14 @@ interface CancelScheduleModalProps {
   emailId: string;
   scheduledTime: string;
   organizationId?: string;
+  timezone?: string | null;
 }
 
 export default function CancelScheduleModal({
   emailId,
   scheduledTime,
   organizationId,
+  timezone,
 }: CancelScheduleModalProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -53,9 +55,10 @@ export default function CancelScheduleModal({
     }
   };
 
-  const scheduledLabel = new Date(scheduledTime).toLocaleString(undefined, {
+  const scheduledLabel = new Date(scheduledTime).toLocaleString("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
+    ...(timezone ? { timeZone: timezone } : {}),
   });
 
   return (
@@ -77,7 +80,8 @@ export default function CancelScheduleModal({
             <AlertDialogDescription>
               Scheduled for{" "}
               <time dateTime={scheduledTime}>{scheduledLabel}</time>. Are you
-              sure you want to move it back to draft?
+              {timezone ? ` (${timezone})` : ""}. Are you sure you want to move
+              it back to draft?
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/components/modal/send-email-modal.tsx
+++ b/components/modal/send-email-modal.tsx
@@ -63,6 +63,7 @@ export function SendEmailModal({
   const [resolvedTimezone, setResolvedTimezone] = useState<string>(
     () => orgTimezone ?? "America/New_York",
   );
+  const displayTimezone = resolvedTimezone.replace(/_/g, " ");
   const [localScheduledDate, setLocalScheduledDate] =
     useState<Moment>(scheduledTimeValue);
 
@@ -246,7 +247,7 @@ export function SendEmailModal({
             timezone={resolvedTimezone}
           />
           <p className="mt-2 text-base text-gray-500">
-            Timezone: <span className="font-medium">{resolvedTimezone}</span>
+            Timezone: <span className="font-medium">{displayTimezone}</span>
           </p>
         </div>
       )}

--- a/components/schedule-email-button.tsx
+++ b/components/schedule-email-button.tsx
@@ -34,6 +34,7 @@ export default function ScheduleEmailButton({
   timezone = DEFAULT_TIMEZONE,
 }: ScheduleEmailProps) {
   const [open, setOpen] = useState(false);
+  const displayTimezone = timezone.replace(/_/g, " ");
 
   // Work in org timezone: use date in TZ for calendar, time string HH:mm for input
   const tzDate = scheduledTimeValue.clone().tz(timezone);
@@ -121,7 +122,7 @@ export default function ScheduleEmailButton({
                 />
               </div>
               <p className="text-muted-foreground text-xs">
-                Timezone: {timezone}
+                Timezone: {displayTimezone}
               </p>
             </div>
           </PopoverContent>

--- a/components/schedule-email-button.tsx
+++ b/components/schedule-email-button.tsx
@@ -70,8 +70,8 @@ export default function ScheduleEmailButton({
 
   const disabledMatcher = useCallback(
     (date: Date) => {
-      const d = moment.tz(date, timezone).startOf("day");
-      return !isValidTime(d);
+      const endOfSelectedDay = moment.tz(date, timezone).endOf("day");
+      return !isValidTime(endOfSelectedDay);
     },
     [timezone, isValidTime],
   );

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -32,13 +32,13 @@ function Calendar({
     ),
     nav: cn("flex items-center gap-1", defaultClassNames?.nav),
     button_previous: cn(
-      "absolute left-1",
+      "absolute left-1 z-10",
       buttonVariants({ variant: "outline" }),
       "h-9 w-9 bg-transparent p-0 opacity-50 hover:opacity-100",
       defaultClassNames?.button_previous,
     ),
     button_next: cn(
-      "absolute right-1",
+      "absolute right-1 z-10",
       buttonVariants({ variant: "outline" }),
       "h-9 w-9 bg-transparent p-0 opacity-50 hover:opacity-100",
       defaultClassNames?.button_next,

--- a/content/docs/advanced-users/ses-integration.mdx
+++ b/content/docs/advanced-users/ses-integration.mdx
@@ -130,6 +130,29 @@ Both providers can coexist - you can use different providers for different domai
 
 ## Troubleshooting
 
+### Scheduled Emails with QStash
+
+Scheduled SES emails are stored in Redis and only send when the queue worker is woken up. In this app, the worker wake-up endpoint is:
+
+`GET /api/cron/email-queue`
+
+To make scheduled sends work reliably, create a QStash schedule that calls this endpoint every minute.
+
+#### QStash Dashboard Setup
+
+1. Open your QStash project in Upstash.
+2. Go to **Schedules**.
+3. Click **Create Schedule**.
+4. Set the destination URL to your live cron endpoint, for example `https://your-app-domain.com/api/cron/email-queue`.
+5. Leave the default HTTP method as `POST` if the UI does not let you change it. The endpoint accepts both `GET` and `POST`.
+6. If you set `CRON_SECRET`, include it either as `Authorization: Bearer <your CRON_SECRET>` or by appending `?token=your-cron-secret` to the URL.
+7. Set the cron expression to `* * * * *`.
+8. Save the schedule.
+
+QStash evaluates cron expressions in `UTC` by default. That is fine for this endpoint because it should run every minute regardless of your campaign timezone.
+
+It can take up to about a minute for a newly created schedule to start firing.
+
 ### Domain Not Verifying
 
 - Check DNS records are correctly configured

--- a/content/docs/advanced-users/ses-integration.mdx
+++ b/content/docs/advanced-users/ses-integration.mdx
@@ -134,7 +134,7 @@ Both providers can coexist - you can use different providers for different domai
 
 Scheduled SES emails are stored in Redis and only send when the queue worker is woken up. In this app, the worker wake-up endpoint is:
 
-`GET /api/cron/email-queue`
+`POST /api/cron/email-queue`
 
 To make scheduled sends work reliably, create a QStash schedule that calls this endpoint every minute.
 
@@ -144,14 +144,16 @@ To make scheduled sends work reliably, create a QStash schedule that calls this 
 2. Go to **Schedules**.
 3. Click **Create Schedule**.
 4. Set the destination URL to your live cron endpoint, for example `https://your-app-domain.com/api/cron/email-queue`.
-5. Leave the default HTTP method as `POST` if the UI does not let you change it. The endpoint accepts both `GET` and `POST`.
-6. If you set `CRON_SECRET`, include it either as `Authorization: Bearer <your CRON_SECRET>` or by appending `?token=your-cron-secret` to the URL.
+5. Set the HTTP method to `POST`.
+6. If you set `CRON_SECRET`, send it in the `Authorization` header as `Bearer <your CRON_SECRET>`.
 7. Set the cron expression to `* * * * *`.
 8. Save the schedule.
 
 QStash evaluates cron expressions in `UTC` by default. That is fine for this endpoint because it should run every minute regardless of your campaign timezone.
 
 It can take up to about a minute for a newly created schedule to start firing.
+
+If `CRON_SECRET` is not set, the endpoint still works without auth. That avoids breaking setups that have not configured a shared secret yet, but header-based auth is recommended for any public deployment.
 
 ### Domain Not Verifying
 


### PR DESCRIPTION
## Description

- Add email queue cron endpoint and unit test

## Motivation and Context

- Closes #204 

## How Has This Been Tested?
QA steps:

- Schedule an email for a future time
- Verify it stays in delayed queue and cron triggers sending at the exact scheduled time
- Confirm sent time matches the specified timezone
- Check timezone display is consistent across UI

## Documentation Changes
- Added doc how to add cron job with SES email scheduling

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
