### PR TITLE
Implement responsive image height adjustment for email HTML

### DIFF
--- a/app/api/emails/preview/route.ts
+++ b/app/api/emails/preview/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { getSession } from "@/lib/auth";
-import { getUnsubscribeUrl } from "@/lib/utils";
+import { fixResponsiveImageHeights, getUnsubscribeUrl } from "@/lib/utils";
 
 export async function POST(request: NextRequest) {
   if (request.method !== "POST") {
@@ -42,6 +42,7 @@ export async function POST(request: NextRequest) {
       const placeholder = `{{${key}}}`;
       html = html.replaceAll(placeholder, value);
     }
+    html = fixResponsiveImageHeights(html);
 
     return NextResponse.json({ html });
   } catch (err: any) {

--- a/lib/actions/send-email.ts
+++ b/lib/actions/send-email.ts
@@ -18,7 +18,12 @@ import prisma from "@/lib/prisma";
 import { Prisma } from "@/prisma/generated/prisma/client";
 import { queueBulkEmails, removeJobs, type EmailJobData } from "@/lib/queue";
 
-import { buildAudienceWhere, getUnsubscribeUrl, logError } from "../utils";
+import {
+  buildAudienceWhere,
+  fixResponsiveImageHeights,
+  getUnsubscribeUrl,
+  logError,
+} from "../utils";
 
 interface OrgEmailClient {
   client: EmailProviderClient;
@@ -143,7 +148,7 @@ const parseContent = async (
       html = html.replaceAll(placeholder, value);
     }
 
-    return html;
+    return fixResponsiveImageHeights(html);
   } catch (error) {
     logError("Error parsing content", error);
     throw new Error("Failed to parse email content");

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,6 +30,26 @@ export const truncate = (str: string, num: number) => {
   return str.slice(0, num) + "...";
 };
 
+export function fixResponsiveImageHeights(html: string) {
+  return html.replace(/<img\b[^>]*>/gi, (tag) => {
+    const styleMatch = tag.match(/\sstyle=(["'])(.*?)\1/i);
+    if (!styleMatch) return tag;
+
+    const [, quote, style] = styleMatch;
+    if (!/(^|;)\s*max-width\s*:\s*100%\s*(;|$)/i.test(style)) return tag;
+
+    const normalizedStyle = style.replace(
+      /(^|;)\s*height\s*:\s*(?!auto\b)[^;]*/i,
+      "$1height:auto",
+    );
+
+    return tag.replace(
+      styleMatch[0],
+      ` style=${quote}${normalizedStyle}${quote}`,
+    );
+  });
+}
+
 export const getBlurDataURL = async (url: string | null) => {
   if (!url) {
     return "data:image/webp;base64,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";


### PR DESCRIPTION
## Description

- Closes #215 

## Motivation and Context

Fixes vertically stretched images in email previews and sent emails by normalizing responsive Maily image HTML to use `height:auto`.

## How Has This Been Tested?

- Tested images on email visually. Ran automated email sending tests

